### PR TITLE
Update language dropdown to grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,24 +244,30 @@
         .lang-dropdown {
             position: absolute; top: calc(100% + 8px); right: 0;
             background: var(--bg-card); border: 1px solid var(--border);
-            border-radius: 8px; overflow: hidden; overflow-y: auto; min-width: 120px; max-height: 320px;
+            border-radius: 10px; overflow: hidden; overflow-y: auto;
+            min-width: 280px; max-height: 400px;
             box-shadow: var(--shadow-card);
             opacity: 0; transform: translateY(-8px); pointer-events: none;
             transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
             z-index: 200;
             backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+            display: grid; grid-template-columns: repeat(3, 1fr);
+            padding: 0.35rem;
+            gap: 1px;
         }
         .lang-dropdown.open {
             opacity: 1; transform: translateY(0); pointer-events: auto;
         }
         .lang-option {
-            display: block; width: 100%; padding: 0.55rem 1rem;
-            font-family: var(--mono); font-size: 0.75rem;
+            display: flex; align-items: center; justify-content: center;
+            padding: 0.5rem 0.4rem;
+            font-family: var(--mono); font-size: 0.7rem;
             color: var(--text-secondary); background: none; border: none;
-            cursor: pointer; text-align: left; transition: all 0.2s ease;
+            cursor: pointer; text-align: center; transition: all 0.2s ease;
+            border-radius: 6px; white-space: nowrap;
         }
         .lang-option:hover { background: var(--accent-dim); color: var(--accent); }
-        .lang-option.active { color: var(--accent); font-weight: 600; }
+        .lang-option.active { color: var(--accent); font-weight: 600; background: var(--accent-dim); }
 
         .nav-toggle { display: none; background: none; border: none; cursor: pointer; padding: 0.5rem; }
         .nav-toggle span {
@@ -617,6 +623,7 @@
             .hero-links a { justify-content: center; }
             .about-stats { grid-template-columns: 1fr; }
             .contact-links { flex-direction: column; align-items: center; }
+            .lang-dropdown { min-width: 200px; grid-template-columns: repeat(2, 1fr); }
         }
 
         /* ── RTL Support ── */
@@ -636,7 +643,6 @@
         [dir="rtl"] .card-links { flex-direction: row-reverse; }
         [dir="rtl"] .contact-links { flex-direction: row-reverse; }
         [dir="rtl"] .lang-dropdown { right: auto; left: 0; }
-        [dir="rtl"] .lang-option { text-align: right; }
         [dir="rtl"] .footer-inner { direction: rtl; }
         [dir="rtl"] ul { padding-right: 1.2em; padding-left: 0; }
     </style>


### PR DESCRIPTION
## Summary
- Convert language dropdown from vertical list to 3-column grid layout
- 2-column grid on mobile (≤480px) for better touch targets
- Centered text with rounded hover states
- Supports scrolling for 30+ languages
- RTL support maintained

## Test plan
- [ ] Verify grid renders correctly on desktop (3 columns)
- [ ] Verify 2-column layout on mobile viewport
- [ ] Verify RTL languages position dropdown correctly
- [ ] Verify scrolling works with many languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)