### PR TITLE
Add LANG_DISPLAY labels for 20 new languages

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -1106,7 +1106,14 @@
     const LANG_DISPLAY = {
         en: 'EN', hi: '\u0939\u093F', ar: '\u0639\u0631',
         he: '\u05E2\u05D1', zh: '\u4E2D', th: '\u0E44\u0E17',
-        ru: '\u0420\u0423', es: 'ES', pt: 'PT', fr: 'FR'
+        ru: '\u0420\u0423', es: 'ES', pt: 'PT', fr: 'FR',
+        ja: '\u65E5', ko: '\uD55C', de: 'DE',
+        it: 'IT', nl: 'NL', pl: 'PL',
+        tr: 'TR', vi: 'VI', id: 'ID',
+        ms: 'MS', sv: 'SV', da: 'DA',
+        fi: 'FI', cs: 'CS', ro: 'RO',
+        uk: '\u0423\u041A', el: '\u0395\u039B', hu: 'HU',
+        bn: '\u09AC\u09BE', ta: '\u0BA4\u0BAE'
     };
 
     /* ── Engine ── */


### PR DESCRIPTION
## Summary
- Add display labels for 20 new languages to LANG_DISPLAY object
- Languages: ja, ko, de, it, nl, pl, tr, vi, id, ms, sv, da, fi, cs, ro, uk, el, hu, bn, ta

🤖 Generated with [Claude Code](https://claude.com/claude-code)