### PR TITLE
Add App Store screenshot carousel to project cards

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -232,6 +232,48 @@ body {
 .stagger-children.visible > :nth-child(6) .tilt-card,
 .stagger-children.visible > :nth-child(6).tilt-card { transition-delay: 0.4s; }
 
+/* ── Screenshot Carousel ── */
+.screenshot-carousel {
+    margin: 0.75rem 0;
+    overflow: hidden;
+    border-radius: 8px;
+}
+.screenshot-track {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    padding: 0.25rem 0;
+}
+.screenshot-track::-webkit-scrollbar {
+    display: none;
+}
+.screenshot-img {
+    flex: 0 0 auto;
+    width: 90px;
+    height: auto;
+    aspect-ratio: 392 / 696;
+    object-fit: cover;
+    border-radius: 8px;
+    scroll-snap-align: start;
+    border: 1px solid var(--border);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    pointer-events: auto;
+}
+.screenshot-img:hover {
+    transform: scale(1.04);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+}
+@media (max-width: 600px) {
+    .screenshot-img {
+        width: 76px;
+    }
+}
+
 /* ── Section Divider (for links page etc.) ── */
 .section-divider {
     width: 100%; margin: 1.5rem 0; position: relative;

--- a/assets/js/shared.js
+++ b/assets/js/shared.js
@@ -78,6 +78,36 @@
 
     document.querySelectorAll('.reveal, .timeline-item, .stagger-children').forEach(el => observer.observe(el));
 
+    // ── Screenshot Carousel — prevent scroll/drag from triggering parent link ──
+    document.querySelectorAll('.screenshot-carousel').forEach(carousel => {
+        const track = carousel.querySelector('.screenshot-track');
+        let isScrolling = false;
+        let startX = 0;
+
+        track.addEventListener('pointerdown', (e) => {
+            startX = e.clientX;
+            isScrolling = false;
+        });
+
+        track.addEventListener('pointermove', (e) => {
+            if (Math.abs(e.clientX - startX) > 5) {
+                isScrolling = true;
+            }
+        });
+
+        // Capture click on the carousel link wrapper — if user was scrolling, prevent navigation
+        const parentLink = carousel.closest('a.project-card-link');
+        if (parentLink) {
+            carousel.addEventListener('click', (e) => {
+                if (isScrolling) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    isScrolling = false;
+                }
+            });
+        }
+    });
+
     // ── Smooth Scroll for anchor links ──
     document.querySelectorAll('a[href^="#"]').forEach(anchor => {
         anchor.addEventListener('click', function (e) {

--- a/index.html
+++ b/index.html
@@ -918,6 +918,15 @@
                         </div>
                         <div class="project-company">Turnip &middot; 2022 - Present</div>
                         <div class="project-desc" data-i18n="projects.turnip.desc">Social app built from scratch -- onboarding, feed, content creation, notifications, and image processing. Cross-functional collaboration from day one.</div>
+                        <div class="screenshot-carousel">
+                            <div class="screenshot-track">
+                                <img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource221/v4/52/8e/c5/528ec5b0-b448-a4b3-4b30-a20f7dd4c8d8/01d34414-57bb-4c07-b84d-c49c0ddc04c0_5.5-1.png/392x696bb.png" alt="Turnip screenshot 1" class="screenshot-img" loading="lazy">
+                                <img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/d2/8c/0b/d28c0bc4-fed6-4540-8c1b-8a13720db468/db938808-a759-4a9d-944c-f9e497fa0223_5.52.png/392x696bb.png" alt="Turnip screenshot 2" class="screenshot-img" loading="lazy">
+                                <img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource221/v4/53/e2/68/53e26827-5495-1ead-0e0f-3debeadd4901/9754194d-3bef-4f14-ab05-d2bae35c9076_5.53.png/392x696bb.png" alt="Turnip screenshot 3" class="screenshot-img" loading="lazy">
+                                <img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/7f/2f/6a/7f2f6ae9-8974-d5a9-03f3-491817b4e79d/e77b52d7-b6c7-4faf-84a5-297f3e0cdc65_5.51.png/392x696bb.png" alt="Turnip screenshot 4" class="screenshot-img" loading="lazy">
+                                <img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource221/v4/08/65/d8/0865d82b-5c34-c097-ff2b-c3789ad4baec/96088092-4264-464b-84be-9a62a3870a6d_Phone_5.5_5.png/392x696bb.png" alt="Turnip screenshot 5" class="screenshot-img" loading="lazy">
+                            </div>
+                        </div>
                         <div class="project-store-hint">
                             <span data-i18n="projects.appstore">View on App Store</span> <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25"/></svg>
                         </div>


### PR DESCRIPTION
## Summary
- Adds a horizontal screenshot carousel to the Turnip project card showing 5 App Store screenshots
- Pure CSS scroll-snap carousel with hidden scrollbar, no external libraries
- JS prevents carousel scroll/drag from triggering the parent card's App Store link

## Notes
- Only **Turnip** has a carousel — the other App Store apps either returned empty screenshot data from the iTunes API (Paytm Money) or are no longer listed (Gwynnie Bee returned 404)
- The carousel component (`.screenshot-carousel`) is reusable and can be added to other cards when screenshots become available

## Changes
- `assets/css/shared.css` — carousel container, track, and thumbnail styles with mobile responsive breakpoint
- `index.html` — carousel HTML with 5 lazy-loaded screenshots in the Turnip card
- `assets/js/shared.js` — pointer tracking to distinguish scroll from click on the carousel

## Test plan
- [ ] Verify carousel scrolls horizontally with snap on desktop and mobile
- [ ] Verify clicking the card (outside carousel) still navigates to the App Store
- [ ] Verify scrolling/dragging the carousel does NOT navigate to the App Store
- [ ] Verify dark and light themes both look correct
- [ ] Verify screenshots load lazily

🤖 Generated with [Claude Code](https://claude.com/claude-code)