### PR TITLE
Fix screenshot carousel vertical stacking

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -235,15 +235,19 @@ body {
 /* ── Screenshot Carousel ── */
 .screenshot-carousel {
     margin: 0.75rem 0;
-    overflow: hidden;
     border-radius: 8px;
+    position: relative;
 }
 .screenshot-track {
     display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
     gap: 0.5rem;
     overflow-x: auto;
+    overflow-y: hidden;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
     -ms-overflow-style: none;
     scrollbar-width: none;
     padding: 0.25rem 0;
@@ -252,8 +256,10 @@ body {
     display: none;
 }
 .screenshot-img {
-    flex: 0 0 auto;
+    flex: 0 0 90px;
     width: 90px;
+    min-width: 90px;
+    max-width: none;
     height: auto;
     aspect-ratio: 392 / 696;
     object-fit: cover;
@@ -263,6 +269,7 @@ body {
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     pointer-events: auto;
+    -webkit-user-drag: none;
 }
 .screenshot-img:hover {
     transform: scale(1.04);
@@ -270,7 +277,10 @@ body {
 }
 @media (max-width: 600px) {
     .screenshot-img {
+        flex: 0 0 76px;
         width: 76px;
+        min-width: 76px;
+        max-width: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- The global `img { max-width: 100% }` from `_reset.scss` was overriding the carousel image widths, causing them to shrink to the container width and stack vertically
- Added `max-width: none` to `.screenshot-img` to override the reset
- Added explicit `flex-direction: row`, `flex-wrap: nowrap`, and `overflow-y: hidden` for robustness

## Root cause
`_sass/_reset.scss` line 108: `img { max-width: 100%; }` — inside a flex container, this makes images shrink to the parent width instead of maintaining their fixed `90px` size.

## Test plan
- [ ] Verify carousel displays horizontally with ~3 screenshots visible
- [ ] Verify horizontal scroll/swipe works on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)