### PR TITLE
Sort language dropdown alphabetically

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,35 +680,35 @@
                     </button>
                     <div class="lang-dropdown" id="langDropdown">
                         <button class="lang-option active" data-lang="en">English</button>
-                        <button class="lang-option" data-lang="hi">हिन्दी</button>
                         <button class="lang-option" data-lang="ar">العربية</button>
-                        <button class="lang-option" data-lang="he">עברית</button>
+                        <button class="lang-option" data-lang="bn">বাংলা</button>
                         <button class="lang-option" data-lang="zh">中文</button>
-                        <button class="lang-option" data-lang="th">ไทย</button>
-                        <button class="lang-option" data-lang="es">Español</button>
-                        <button class="lang-option" data-lang="pt">Português</button>
-                        <button class="lang-option" data-lang="fr">Français</button>
-                        <button class="lang-option" data-lang="ru">Русский</button>
-                        <button class="lang-option" data-lang="de">Deutsch</button>
-                        <button class="lang-option" data-lang="it">Italiano</button>
-                        <button class="lang-option" data-lang="nl">Nederlands</button>
-                        <button class="lang-option" data-lang="ja">日本語</button>
-                        <button class="lang-option" data-lang="ko">한국어</button>
-                        <button class="lang-option" data-lang="id">Indonesia</button>
-                        <button class="lang-option" data-lang="pl">Polski</button>
-                        <button class="lang-option" data-lang="tr">Türkçe</button>
-                        <button class="lang-option" data-lang="ms">Melayu</button>
-                        <button class="lang-option" data-lang="vi">Tiếng Việt</button>
-                        <button class="lang-option" data-lang="sv">Svenska</button>
-                        <button class="lang-option" data-lang="ro">Română</button>
                         <button class="lang-option" data-lang="cs">Čeština</button>
                         <button class="lang-option" data-lang="da">Dansk</button>
+                        <button class="lang-option" data-lang="nl">Nederlands</button>
                         <button class="lang-option" data-lang="fi">Suomi</button>
-                        <button class="lang-option" data-lang="uk">Українська</button>
+                        <button class="lang-option" data-lang="fr">Français</button>
+                        <button class="lang-option" data-lang="de">Deutsch</button>
                         <button class="lang-option" data-lang="el">Ελληνικά</button>
+                        <button class="lang-option" data-lang="he">עברית</button>
+                        <button class="lang-option" data-lang="hi">हिन्दी</button>
                         <button class="lang-option" data-lang="hu">Magyar</button>
-                        <button class="lang-option" data-lang="bn">বাংলা</button>
+                        <button class="lang-option" data-lang="id">Indonesia</button>
+                        <button class="lang-option" data-lang="it">Italiano</button>
+                        <button class="lang-option" data-lang="ja">日本語</button>
+                        <button class="lang-option" data-lang="ko">한국어</button>
+                        <button class="lang-option" data-lang="ms">Melayu</button>
+                        <button class="lang-option" data-lang="pl">Polski</button>
+                        <button class="lang-option" data-lang="pt">Português</button>
+                        <button class="lang-option" data-lang="ro">Română</button>
+                        <button class="lang-option" data-lang="ru">Русский</button>
+                        <button class="lang-option" data-lang="es">Español</button>
+                        <button class="lang-option" data-lang="sv">Svenska</button>
                         <button class="lang-option" data-lang="ta">தமிழ்</button>
+                        <button class="lang-option" data-lang="th">ไทย</button>
+                        <button class="lang-option" data-lang="tr">Türkçe</button>
+                        <button class="lang-option" data-lang="uk">Українська</button>
+                        <button class="lang-option" data-lang="vi">Tiếng Việt</button>
                     </div>
                 </div>
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">


### PR DESCRIPTION
## Summary
- Sort the 30-language dropdown alphabetically by English name
- English stays pinned at the top as the default language
- Makes it much easier for users to find their language in the grid

## Test plan
- [ ] Open the site and click the language switcher
- [ ] Verify languages appear in A-Z order (Arabic, Bengali, Chinese, Czech, Danish, Dutch, ...)
- [ ] Verify English remains the first option
- [ ] Verify switching languages still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)