### PR TITLE
Fix mobile horizontal scroll and language dropdown readability

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -237,6 +237,7 @@ body {
     margin: 0.75rem 0;
     border-radius: 8px;
     position: relative;
+    overflow: hidden;
 }
 .screenshot-track {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
         .lang-toggle:hover { border-color: var(--accent); color: var(--accent); }
         .lang-dropdown {
             position: absolute; top: calc(100% + 8px); right: 0;
-            background: var(--bg-card); border: 1px solid var(--border);
+            background: var(--bg-secondary); border: 1px solid var(--border);
             border-radius: 10px; overflow: hidden; overflow-y: auto;
             min-width: 280px; max-height: 400px;
             box-shadow: var(--shadow-card);


### PR DESCRIPTION
## Summary
- **Fix horizontal page scroll on mobile**: Added `overflow: hidden` to `.screenshot-carousel` so the horizontally-scrolling screenshot track stays contained within the card instead of causing full-page horizontal scroll
- **Fix language dropdown readability**: Changed dropdown background from `var(--bg-card)` (2.5% opacity, nearly transparent) to `var(--bg-secondary)` (fully opaque) so text is clearly readable against the background in both themes

## Test plan
- [ ] Open site on mobile (or narrow viewport) — verify no horizontal page scroll on project cards with screenshots
- [ ] Screenshot carousel still scrolls horizontally within its container
- [ ] Open language dropdown in dark mode — verify opaque background, text is readable
- [ ] Open language dropdown in light mode — same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)