### PR TITLE
Fix screenshot carousel overflowing on mobile

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -238,6 +238,8 @@ body {
     border-radius: 8px;
     position: relative;
     overflow: hidden;
+    min-width: 0;
+    max-width: 100%;
 }
 .screenshot-track {
     display: flex;

--- a/index.html
+++ b/index.html
@@ -468,8 +468,9 @@
         .projects-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1.5rem; }
         a.project-card-link {
             text-decoration: none; color: inherit; display: block;
+            min-width: 0; overflow: hidden;
         }
-        .project-card { padding: 2rem; cursor: default; }
+        .project-card { padding: 2rem; cursor: default; min-width: 0; }
         a.project-card-link .project-card { cursor: pointer; }
         .project-header { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }
         .project-icon {


### PR DESCRIPTION
## Summary
- CSS grid items have implicit `min-width: auto` which prevents them from shrinking below their content size
- The carousel's `flex-wrap: nowrap` track with fixed-width images forced grid items wider than the viewport, causing horizontal page scroll on mobile
- Added `min-width: 0` and `overflow: hidden` to `.project-card-link` and `.project-card` (the grid items) to break the implicit min-width chain
- Added `min-width: 0` and `max-width: 100%` to `.screenshot-carousel` for an extra containment layer
- The carousel now scrolls horizontally **within** the card on mobile, just like on desktop

## Test plan
- [ ] Open site on mobile or narrow viewport (~375px)
- [ ] Scroll to "Apps shipped" section — no horizontal page overflow
- [ ] Screenshot carousels in Turnip and Paytm Money cards scroll horizontally within the card
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)