### PR TITLE
[codex] link knowledge garden

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,6 +668,7 @@
                     <li><a href="#about" data-i18n="nav.about">About</a></li>
                     <li><a href="#experience" data-i18n="nav.experience">Experience</a></li>
                     <li><a href="#projects" data-i18n="nav.projects">Projects</a></li>
+                    <li><a href="/knowledge/">Knowledge</a></li>
                     <li><a href="#skills" data-i18n="nav.skills">Skills</a></li>
                     <li><a href="#contact" data-i18n="nav.contact">Contact</a></li>
                 </ul>
@@ -1351,6 +1352,12 @@
                 <div class="lo-card lo-stagger-5"><a href="https://github.com/v-i-s-h-a-l" target="_blank" rel="noopener">
                     <div class="lo-icon i-github"><svg viewBox="0 0 24 24"><path d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34-.46-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.87 1.52 2.34 1.07 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.92 0-1.11.38-2 1.03-2.71-.1-.25-.45-1.29.1-2.64 0 0 .84-.27 2.75 1.02.79-.22 1.65-.33 2.5-.33.85 0 1.71.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.35.2 2.39.1 2.64.65.71 1.03 1.6 1.03 2.71 0 3.82-2.34 4.66-4.57 4.91.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2z"/></svg></div>
                     <div class="lo-text"><div class="lo-title">GitHub</div><div class="lo-sub">@v-i-s-h-a-l</div></div>
+                    <span class="lo-arrow"><svg viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg></span>
+                </a></div>
+
+                <div class="lo-card lo-stagger-5"><a href="/knowledge/">
+                    <div class="lo-icon i-portfolio"><svg viewBox="0 0 24 24"><path d="M4 4h8a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H4V4zm16 0h-2a6 6 0 0 1 1 3.32V17h1V4zM6 7v2h6V7H6zm0 4v2h8v-2H6z"/></svg></div>
+                    <div class="lo-text"><div class="lo-title">Knowledge Garden</div><div class="lo-sub">agent-auditable essays</div></div>
                     <span class="lo-arrow"><svg viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg></span>
                 </a></div>
 


### PR DESCRIPTION
## Summary

Adds a visible link from the personal website to the new /knowledge/ GitHub Pages knowledge garden.

## Validation

- Static link inspection passed locally.
- Full Jekyll build could not run locally because the jekyll executable is missing from the current Bundler environment.

## Dependency

Merge after v-i-s-h-a-l/knowledge PR #1 is merged and GitHub Pages is configured.