### PR TITLE
[codex] link Aura Knowledge

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,7 +668,7 @@
                     <li><a href="#about" data-i18n="nav.about">About</a></li>
                     <li><a href="#experience" data-i18n="nav.experience">Experience</a></li>
                     <li><a href="#projects" data-i18n="nav.projects">Projects</a></li>
-                    <li><a href="/knowledge/">Knowledge</a></li>
+                    <li><a href="https://aura-knowledge.github.io/">Knowledge</a></li>
                     <li><a href="#skills" data-i18n="nav.skills">Skills</a></li>
                     <li><a href="#contact" data-i18n="nav.contact">Contact</a></li>
                 </ul>
@@ -1355,9 +1355,9 @@
                     <span class="lo-arrow"><svg viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg></span>
                 </a></div>
 
-                <div class="lo-card lo-stagger-5"><a href="/knowledge/">
+                <div class="lo-card lo-stagger-5"><a href="https://aura-knowledge.github.io/">
                     <div class="lo-icon i-portfolio"><svg viewBox="0 0 24 24"><path d="M4 4h8a4 4 0 0 1 4 4v12a3 3 0 0 0-3-3H4V4zm16 0h-2a6 6 0 0 1 1 3.32V17h1V4zM6 7v2h6V7H6zm0 4v2h8v-2H6z"/></svg></div>
-                    <div class="lo-text"><div class="lo-title">Knowledge Garden</div><div class="lo-sub">agent-auditable essays</div></div>
+                    <div class="lo-text"><div class="lo-title">Aura Knowledge</div><div class="lo-sub">agent-auditable essays</div></div>
                     <span class="lo-arrow"><svg viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5"/></svg></span>
                 </a></div>
 


### PR DESCRIPTION
## Summary

Updates the personal site doorway after moving the knowledge garden into the Aura Knowledge organization:

- points the top navigation Knowledge link at `https://aura-knowledge.github.io/`
- renames the overlay card to Aura Knowledge
- points the overlay card at the org Pages root

## Validation

- `git diff --check`
- verified `https://aura-knowledge.github.io/` returns 200
